### PR TITLE
Make it work in 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ hs_err_pid*
 target/
 hardcopy.*
 screenlog.*
+
+
+sms-sent/

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ Selenium script to scrape for Swedish consulate passport renewal appointments
 
 ## Usage
 
-1. Get a https://www.twilio.com/ trial account, get a twilio phone number & verify the phone number you want to send sms to
+1. Get a [Sinch](https://www.sinch.com) trial account, get a Sinch phone number & verify the phone number you want to send sms to
 2. `brew install maven` (if you don’t have maven + java)
 3. `git clone git@github.com:danielnorberg/konsulatet.git`
 4. `cd konsulatet`
-5. `TWILIO_SID=badf00d TWILIO_TOKEN=badf00d NOTIFICATION_NUMBERS=+12222222222,+13333333333 TWILIO_NUMBER=+14444444444 ./run.sh`
+5. `SINCH_PLAN_ID=badf00d SINCH_TOKEN=badf00d RECIPIENTS_NUMBERS=+12222222222,+13333333333 SENDER_NUMBER=+14444444444 ./run.sh`
 6. Verify that you get the hello world SMS on startup, otherwise something is wrong and you might not get any notifications for appointments.
 
-* The `TWILIO_SID`, `TWILIO_TOKEN` env vars should be set to your twilio SID and auth token.
-* `TWILIO_NUMBER` should be your assigned Twilio phone number.
-* `NOTIFICATION_NUMBERS` Can be one or more comma separated numbers to send SMS to. Note that the numbers must be verified in your Twilio account.
+* The `SINCH_PLAN_ID`, `SINCH_TOKEN` env vars should be set to your Sinch plan ID and auth token.
+* `SENDER_NUMBER` should be your assigned Sinch phone number that will send the SMS.
+* `RECIPIENTS_NUMBERS` Can be one or more comma separated numbers to send an SMS to. Note that the numbers must be verified in your Sinch account.
 
 ## Note
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.twilio.sdk</groupId>
-      <artifactId>twilio</artifactId>
-      <version>8.9.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.30</version>
@@ -58,6 +53,11 @@
       <artifactId>mockito-core</artifactId>
       <version>3.8.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sinch</groupId>
+      <artifactId>sdk-sms</artifactId>
+      <version>1.1.0</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>3.141.59</version>
+      <version>4.18.1</version>
     </dependency>
     <dependency>
       <groupId>io.github.bonigarcia</groupId>
       <artifactId>webdrivermanager</artifactId>
-      <version>4.3.1</version>
+      <version>5.7.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/konsulatet/AppointmentChecker.java
+++ b/src/main/java/konsulatet/AppointmentChecker.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
 import java.lang.invoke.MethodHandles;
+import java.time.Duration;
 import java.util.Map;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -68,7 +69,7 @@ class AppointmentChecker implements AutoCloseable {
 
   boolean checkappointments(String office) {
     var wait =
-        new WebDriverWait(driver, 300, 10)
+        new WebDriverWait(driver, Duration.ofSeconds(300), Duration.ofSeconds(10))
             .ignoring(StaleElementReferenceException.class)
             .ignoring(ElementClickInterceptedException.class)
             .ignoring(NoSuchElementException.class);

--- a/src/main/java/konsulatet/Main.java
+++ b/src/main/java/konsulatet/Main.java
@@ -54,12 +54,16 @@ public class Main implements AutoCloseable {
           .forEach(
               (office, url) -> {
                 log.info("Checking for appointments at {}", office);
-                var maybeAvailable = appointmentChecker.checkappointments(office);
-                if (maybeAvailable) {
-                  log.info("Appointments might be available at {}, notifying!", office);
-                  smsSender.sendSMS(
-                      office, "Appointments might be available at " + office + ", check at " + url);
-                } else {
+                try {
+                  var maybeAvailable = appointmentChecker.checkappointments(office);
+                  if (maybeAvailable) {
+                    log.info("Appointments might be available at {}, notifying!", office);
+                    smsSender.sendSMS(
+                        office, "Appointments might be available at " + office + ", check at " + url);
+                  } else {
+                    log.info("No appointments available at {}", office);
+                  }
+                } catch (Exception exception) {
                   log.info("No appointments available at {}", office);
                 }
               });


### PR DESCRIPTION
I tried running this locally to find some passport times but it unfortunately didn’t work anymore. This PR makes it work in 2024.

* Bump WebDriver and Selenium to support latest Chrome.
  * The previous versions only supported up to Chrome 114.x I think it was.
  * It seems the API behaviors have change a bit. The `wait.until(ExpectedConditions.visibilityOfElementLocated(TIDSBOKNING_PANEL));` call started throwing an exception when the timeout was reached. This caused the app to crash. I’ve resolved this by adding a `try { } catch { }` block around the `appointmentChecker.checkappointments(office);` call in `Main.java`.
* Switch from Twilio to [Sinch](http://sinch.com) as the SMS vendor.
  * Twilio has added (on Jan 1st, 2024) a mandatory business verification step.
  * Sinch offers some free credit and the ability to send an SMS to a verified number.

![Screenshot 2024-03-05 at 3 14 16 PM](https://github.com/danielnorberg/konsulatet/assets/23453/8bbe5632-b20c-4ed4-8968-f03cda2bbdfd)